### PR TITLE
Eve commit

### DIFF
--- a/Marlin/src/extensible-ui/lib/ftdi_eve_functions.h
+++ b/Marlin/src/extensible-ui/lib/ftdi_eve_functions.h
@@ -125,6 +125,7 @@ class CLCD {
     static void     spi_deselect (void);
 
     static uint8_t  _soft_spi_transfer (uint8_t spiOutByte);
+    static void    _soft_spi_send (uint8_t spiOutByte);
 
     static void     spi_send(uint8_t spiOutByte);
     static uint8_t  spi_recv();

--- a/Marlin/src/extensible-ui/lib/ftdi_eve_spi.cpp
+++ b/Marlin/src/extensible-ui/lib/ftdi_eve_spi.cpp
@@ -152,9 +152,29 @@ void CLCD::test_pulse(void)
   }
 #endif
 
+#if defined(CLCD_USE_SOFT_SPI)
+  void CLCD::_soft_spi_send (uint8_t spiOutByte) {
+    uint8_t spiIndex  = 0x80;
+    uint8_t k;
+
+    for(k = 0; k <8; k++) {         // Output each bit of spiOutByte
+      if(spiOutByte & spiIndex) {   // Output MOSI Bit
+        WRITE(CLCD_SOFT_SPI_MOSI, 1);
+      }
+      else {
+        WRITE(CLCD_SOFT_SPI_MOSI, 0);
+      }
+      WRITE(CLCD_SOFT_SPI_SCLK, 1);   // Pulse Clock
+      WRITE(CLCD_SOFT_SPI_SCLK, 0);
+    
+      spiIndex >>= 1;
+    }
+  }
+#endif
+
 void CLCD::spi_send(uint8_t spiOutByte) {
   #if defined(CLCD_USE_SOFT_SPI)
-    _soft_spi_transfer(spiOutByte);
+    _soft_spi_send(spiOutByte);
   #elif defined(USE_MARLIN_IO)
     spiSend(spiOutByte);
   #else

--- a/Marlin/src/extensible-ui/lib/ftdi_eve_spi.cpp
+++ b/Marlin/src/extensible-ui/lib/ftdi_eve_spi.cpp
@@ -77,7 +77,7 @@
 
 void CLCD::spi_init (void) {
   SET_OUTPUT(CLCD_MOD_RESET); // Module Reset (a.k.a. PD, not SPI)
-  WRITE(CLCD_MOD_RESET, 1);
+  WRITE(CLCD_MOD_RESET, 0); // start with module in power-down
 
   SET_OUTPUT(CLCD_SPI_CS);
   WRITE(CLCD_SPI_CS, 1);
@@ -98,7 +98,6 @@ void CLCD::spi_init (void) {
   SPI.beginTransaction(SPISettings(14000000, MSBFIRST, SPI_MODE0));
 #endif
 
-  delay(50);
 }
 
 // CLCD SPI - Chip Select

--- a/Marlin/src/extensible-ui/lib/ftdi_eve_timings.h
+++ b/Marlin/src/extensible-ui/lib/ftdi_eve_timings.h
@@ -45,21 +45,79 @@
  *    http://www.4dsystems.com.au/productpages/4DLCD-FT843/downloads/FT843-4.3-Display_datasheet_R_1_2.pdf
  *
  */
-namespace FTDI_LCD_480x272 {
-  const int Vsync0  =    0;
-  const int Vsync1  =   10;
-  const int Voffset =   12;
-  const int Vcycle  =  292;
-  const int Hsync0  =    0;
-  const int Hsync1  =   41;
-  const int Hoffset =   43;
-  const int Hcycle  =  548;
-  const int Hsize   =  480;
-  const int Vsize   =  272;
-  const int Pclkpol =    1;
-  const int Swizzle =    0;
-  const int Pclk    =    5;
-  const int Clksel  = 0x44;
+
+namespace FTDI_VM800B35A {
+  const uint16_t Hsize   =  320;
+  const uint16_t Vsize   =  240;
+  const uint16_t Vsync0  =    0;
+  const uint16_t Vsync1  =   2;
+  const uint16_t Voffset =   13;
+  const uint16_t Vcycle  =  263;
+  const uint16_t Hsync0  =    0;
+  const uint16_t Hsync1  =   10;
+  const uint16_t Hoffset =   70;
+  const uint16_t Hcycle  =  408;
+  const uint8_t Pclkpol  =  0;
+  const uint8_t Swizzle  =  2;
+  const uint8_t CSpread  =  1;
+  const uint8_t Pclk     =  8;
+  const uint8_t Use_Crystal = 1; // 0 = use internal oscillator, 1 = module has a crystal populated
+  const uint16_t touch_threshold = 1200; /* touch-sensitivity */
+  const uint8_t GPIO_1_Audio_Shutdown = 1; /* 1 = does use GPIO01 for amplifier control, 0 = not in use for Audio */
+
+  const uint32_t default_transform_a = 0xffff7f55;
+  const uint32_t default_transform_b = 0x00000000;
+  const uint32_t default_transform_c = 0x01f0d673;
+  const uint32_t default_transform_d = 0x00000084;
+  const uint32_t default_transform_e = 0x000054b9;
+  const uint32_t default_transform_f = 0xffe0f006;
+}
+
+namespace FTDI_FT800CB {
+  const uint16_t Hsize   =  480;
+  const uint16_t Vsize   =  272;
+  const uint16_t Vsync0  =    0;
+  const uint16_t Vsync1  =   10;
+  const uint16_t Voffset =   12;
+  const uint16_t Vcycle  =  292;
+  const uint16_t Hsync0  =    0;
+  const uint16_t Hsync1  =   41;
+  const uint16_t Hoffset =   43;
+  const uint16_t Hcycle  =  548;
+  const uint8_t Pclkpol  =  1;
+  const uint8_t Swizzle  =  0;
+  const uint8_t CSpread  =  1;
+  const uint8_t Pclk     =  5;
+  const uint8_t Use_Crystal = 1; // 0 = use internal oscillator, 1 = module has a crystal populated
+  const uint16_t touch_threshold = 2000; /* touch-sensitivity */
+  const uint8_t GPIO_1_Audio_Shutdown = 0;
+
+  const uint32_t default_transform_a = 0x00008100;
+  const uint32_t default_transform_b = 0x00000000;
+  const uint32_t default_transform_c = 0xFFF18000;
+  const uint32_t default_transform_d = 0x00000000;
+  const uint32_t default_transform_e = 0xFFFFB100;
+  const uint32_t default_transform_f = 0x0120D000;
+}
+
+namespace FTDI_4DLCD_FT843 {
+  const uint16_t Hsize   =  480;
+  const uint16_t Vsize   =  272;
+  const uint16_t Vsync0  =    0;
+  const uint16_t Vsync1  =   10;
+  const uint16_t Voffset =   12;
+  const uint16_t Vcycle  =  292;
+  const uint16_t Hsync0  =    0;
+  const uint16_t Hsync1  =   41;
+  const uint16_t Hoffset =   43;
+  const uint16_t Hcycle  =  548;
+  const uint8_t Pclkpol  =  1;
+  const uint8_t Swizzle  =  0;
+  const uint8_t CSpread  =  1;
+  const uint8_t Pclk     =  5;
+  const uint8_t Use_Crystal = 1; // 0 = use internal oscillator, 1 = module has a crystal populated
+  const uint16_t touch_threshold = 1200; /* touch-sensitivity */
+  const uint8_t GPIO_1_Audio_Shutdown = 1;
 
   const uint32_t default_transform_a = 0x00008100;
   const uint32_t default_transform_b = 0x00000000;
@@ -81,21 +139,24 @@ namespace FTDI_LCD_480x272 {
  *    http://www.haoyuelectronics.com/Attachment/HY5-LCD-HD/KD50G21-40NT-A1.pdf
  *
  */
-namespace FTDI_LCD_800x480 {
-  const int Vsync0  =    0;
-  const int Vsync1  =   13;
-  const int Voffset =   16;
-  const int Vcycle  =  525;
-  const int Hsync0  =    0;
-  const int Hsync1  =   40;
-  const int Hoffset =   88;
-  const int Hcycle  =  928;
-  const int Hsize   =  800;
-  const int Vsize   =  480;
-  const int Pclkpol =    1;
-  const int Swizzle =    0;
-  const int Pclk    =    2;
-  const int Clksel  = 0x45;
+namespace FTDI_FT810CB {
+  const uint16_t Hsize   =  800;
+  const uint16_t Vsize   =  480;
+  const uint16_t Vsync0  =    0;
+  const uint16_t Vsync1  =   2;
+  const uint16_t Voffset =   13;
+  const uint16_t Vcycle  =  525;
+  const uint16_t Hsync0  =    0;
+  const uint16_t Hsync1  =   20;
+  const uint16_t Hoffset =   64;
+  const uint16_t Hcycle  =  952;
+  const uint8_t Pclkpol  =  1;
+  const uint8_t Swizzle  =  0;
+  const uint8_t CSpread  =  1;
+  const uint8_t Pclk     =  2;
+  const uint8_t Use_Crystal = 1; // 0 = use internal oscillator, 1 = module has a crystal populated
+  const uint16_t touch_threshold = 2000; /* touch-sensitivity */
+  const uint8_t GPIO_1_Audio_Shutdown = 0;
 
   const uint32_t default_transform_a = 0x0000D8B9;
   const uint32_t default_transform_b = 0x00000124;
@@ -105,10 +166,14 @@ namespace FTDI_LCD_800x480 {
   const uint32_t default_transform_f = 0x01F0AF70;
 }
 
-#if defined(LCD_800x480)
-  using namespace FTDI_LCD_800x480;
-#elif defined(LCD_480x272)
-  using namespace FTDI_LCD_480x272;
+#if defined(LCD_VM800B35A)
+  using namespace FTDI_VM800B35A;
+#elif defined(LCD_FT800CB)
+  using namespace FTDI_FT800CB;
+#elif defined(LCD_4DLCD_FT843)
+  using namespace FTDI_4DLCD_FT843;
+#elif defined(LCD_FT810CB)
+  using namespace FTDI_FT810CB;
 #else
   #error Unknown or no resolution specified. To add a new resolution, modify "ftdi_eve_timings.h"
 #endif

--- a/Marlin/src/extensible-ui/lib/ui_config.h
+++ b/Marlin/src/extensible-ui/lib/ui_config.h
@@ -25,10 +25,40 @@
 // If using a pre-configured display for Marlin, select it below. Otherwise,
 // select OTHER_DISPLAY to configure a custom display.
 
-#define AO_COLOR_DISPLAY_REV_B
+//#define AO_COLOR_DISPLAY_REV_B
 //#define AO_COLOR_DISPLAY_REV_C_EXP1
 //#define AO_COLOR_DISPLAY_REV_C_EXP2
 //#define OTHER_DISPLAY
+#define CR10_TFT
+
+
+#if defined(CR10_TFT)
+     // Define whether an FT800 or FT810+ chip is being used
+    //#define USE_FTDI_FT800
+    #define USE_FTDI_FT810
+
+    // Define the display resolution
+    //#define LCD_320x240
+    #define LCD_480x272
+    //#define LCD_800x480
+
+    // Defines how to orient the display. An inverted (i.e. upside-down) display
+    // is supported on the FT800. The FT810 or better also support a portrait
+    // and mirrored orientation.
+    #define USE_INVERTED_ORIENTATION
+    //#define USE_PORTRAIT_ORIENTATION
+    //#define USE_MIRRORED_ORIENTATION
+ 
+    #define CLCD_USE_SOFT_SPI
+    #define CLCD_SOFT_SPI_SCLK  LCD_PINS_D4      // PORTA1               Pin 6
+    #define CLCD_SOFT_SPI_MOSI  LCD_PINS_ENABLE  // PORTC1               Pin 8
+    #define CLCD_SPI_CS         LCD_PINS_RS      // PORTA3               Pin 7
+    #define CLCD_SOFT_SPI_MISO  16               // PORTC0   BTN_ENC     Pin 2
+    #define CLCD_MOD_RESET      11               // PORTD3   BTN_EN1     Pin 3
+    #define CLCD_AUX_0          10               // PORTD2   BTN_EN2     Pin 5
+    #define CLCD_AUX_1          BEEPER_PIN       // PORTA4               Pin 1
+//    #define CLCD_AUX_2          BEEPER_PIN
+#endif
 
 #if defined(OTHER_DISPLAY)
     // Define whether an FT800 or FT810+ chip is being used

--- a/Marlin/src/extensible-ui/lib/ui_config.h
+++ b/Marlin/src/extensible-ui/lib/ui_config.h
@@ -32,16 +32,19 @@
 #define CR10_TFT
 
 
+// Define whether an FT800 or FT810+ chip is being used
+//#define USE_FTDI_FT800
+#define USE_FTDI_FT810
+
+// Define the display used
+
+//#define LCD_VM800N35A       // FTDI 3.5" 320x240 with FT800
+#define LCD_FT800CB         // Haoyu 5" 480x272 with FT800
+//#define LCD_4DLCD_FT843     // 4D Systems 4.3" 480x272 wuth FT800
+//#define LCD_FT810CB         // Haoyu 5" 800x480 with FT810
+
+
 #if defined(CR10_TFT)
-     // Define whether an FT800 or FT810+ chip is being used
-    //#define USE_FTDI_FT800
-    #define USE_FTDI_FT810
-
-    // Define the display resolution
-    //#define LCD_320x240
-    #define LCD_480x272
-    //#define LCD_800x480
-
     // Defines how to orient the display. An inverted (i.e. upside-down) display
     // is supported on the FT800. The FT810 or better also support a portrait
     // and mirrored orientation.


### PR DESCRIPTION
For the most part this includes a reworked init().
I started adding more settings and changing the names to reflect modules instead just resolutions.
FTDI_FT800CB and FTDI_4DLCD_FT843 are almost the same.
But FTDI_4DLCD_FT843 does use GPIO_1 for amplifier control while FT800CB does not.
And the resistive touch from HAOYU displays is rather cheap so it needs a higher sensitivity than quality modules like the ones from FTDI or 4D Systems.

The distinction between FT800 and FT810 also is misleading.
It is FT80x and FT81x really.
But I did not touch that.

I have my spare CR-10 controller board with the FT800CB up and running right now on my desk.
Well, technically it is a FT810CB board with the panel from a FT800CB.

I have not checked into higher level stuff but as it still flickers from time to time and still gets stuck when playing with the display and still sends data to the display without a noticeable pause, the interface layer holds some bugs to be fixed.
 